### PR TITLE
fix: death system combat logging and state sync issues

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -280,7 +280,7 @@ end)
 CreateThread(function()
     repeat Wait(1000) until LocalPlayer.state['isLoggedIn']
     while true do
-        local health = LocalPlayer.state.health
+        local health = GetEntityHealth(cache.ped)
             if health == 0 and deathactive == false then
                 exports.spawnmanager:setAutoSpawn(false)
                 deathTimerStarted = true
@@ -299,9 +299,9 @@ end)
 ---------------------------------------------------------------------
 RegisterNetEvent('RSGCore:Client:OnPlayerLoaded', function()
     local PlayerData = RSGCore.Functions.GetPlayerData()
-    local health = LocalPlayer.state.health
+    local health = GetEntityHealth(cache.ped)
         if PlayerData.metadata['isdead'] then
-            if health >= 0 and deathactive == false then
+            if health ~= 0 and deathactive == false then
                 SetEntityHealth(cache.ped, 0)
                 exports.spawnmanager:setAutoSpawn(false)
                 deathTimerStarted = true

--- a/client/client.lua
+++ b/client/client.lua
@@ -275,19 +275,44 @@ CreateThread(function()
 end)
 
 ---------------------------------------------------------------------
--- player update health loop
+-- player death loop
 ---------------------------------------------------------------------
 CreateThread(function()
     repeat Wait(1000) until LocalPlayer.state['isLoggedIn']
     while true do
-        if not LocalPlayer.state.invincible then 
-            local health = GetEntityHealth(cache.ped)
-            if LocalPlayer.state.health ~= health then 
-                LocalPlayer.state:set('health', health, true)
+        local health = LocalPlayer.state.health
+            if health == 0 and deathactive == false then
+                exports.spawnmanager:setAutoSpawn(false)
+                deathTimerStarted = true
+                deathTimer()
+                deathLog()
+                deathactive = true
+                TriggerServerEvent("RSGCore:Server:SetMetaData", "isdead", true)
+                LocalPlayer.state:set('isdead', true, true)
+                TriggerEvent('rsg-medic:client:DeathCam')
             end
-        end
         Wait(1000)
     end
+end)
+---------------------------------------------------------------------
+-- player combat log check
+---------------------------------------------------------------------
+RegisterNetEvent('RSGCore:Client:OnPlayerLoaded', function()
+    local PlayerData = RSGCore.Functions.GetPlayerData()
+    local health = LocalPlayer.state.health
+        if PlayerData.metadata['isdead'] then
+            if health >= 0 and deathactive == false then
+                SetEntityHealth(cache.ped, 0)
+                exports.spawnmanager:setAutoSpawn(false)
+                deathTimerStarted = true
+                deathTimer()
+                deathLog()
+                deathactive = true
+                TriggerServerEvent("RSGCore:Server:SetMetaData", "isdead", true)
+                LocalPlayer.state:set('isdead', true, true)
+                TriggerEvent('rsg-medic:client:DeathCam')
+            end
+        end
 end)
 
 ---------------------------------------------------------------------
@@ -608,6 +633,8 @@ end)
 RegisterNetEvent('rsg-medic:client:KillPlayer')
 AddEventHandler('rsg-medic:client:KillPlayer', function()
     SetEntityHealth(cache.ped, 0)
+    TriggerServerEvent('RSGCore:Server:SetMetaData', 'isdead', true)
+    LocalPlayer.state:set('isDead', true, true)
 end)
 
 ---------------------------------------------------------------------


### PR DESCRIPTION
Fixed several issues with the death system where players could exploit combat logging

What was broken:
- Players could disconnect while dead and come back alive
- Inconsistent handling of forced player deaths

What I fixed:
- Added proper combat log detection when players reconnect
- Cleaned up the KillPlayer event to use the same death flow as everything else
