### PR TITLE
Check if cache.ped entity exists before accessing its health

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -259,16 +259,18 @@ end)
 CreateThread(function()
     repeat Wait(1000) until LocalPlayer.state['isLoggedIn']
     while true do
-        local health = GetEntityHealth(cache.ped)
-        if health == 0 and deathactive == false and not LocalPlayer.state.invincible then
-            exports.spawnmanager:setAutoSpawn(false)
-            deathTimerStarted = true
-            deathTimer()
-            deathLog()
-            deathactive = true
-            TriggerServerEvent("RSGCore:Server:SetMetaData", "isdead", true)
-            LocalPlayer.state:set('isDead', true, true)
-            TriggerEvent('rsg-medic:client:DeathCam')
+        if DoesEntityExist(cache.ped) then
+            local health = GetEntityHealth(cache.ped)
+            if health == 0 and deathactive == false and not LocalPlayer.state.invincible then
+                exports.spawnmanager:setAutoSpawn(false)
+                deathTimerStarted = true
+                deathTimer()
+                deathLog()
+                deathactive = true
+                TriggerServerEvent("RSGCore:Server:SetMetaData", "isdead", true)
+                LocalPlayer.state:set('isDead', true, true)
+                TriggerEvent('rsg-medic:client:DeathCam')
+            end
         end
         Wait(1000)
     end
@@ -277,7 +279,8 @@ end)
 CreateThread(function()
     repeat Wait(1000) until LocalPlayer.state['isLoggedIn']
     while true do
-        local health = GetEntityHealth(cache.ped)
+        if DoesEntityExist(cache.ped) then
+            local health = GetEntityHealth(cache.ped)
             if health == 0 and deathactive == false then
                 exports.spawnmanager:setAutoSpawn(false)
                 deathTimerStarted = true
@@ -288,6 +291,7 @@ CreateThread(function()
                 LocalPlayer.state:set('isdead', true, true)
                 TriggerEvent('rsg-medic:client:DeathCam')
             end
+        end
         Wait(1000)
     end
 end)


### PR DESCRIPTION
**Description**

The issue is that `cache.ped` doesn't always hold a valid player ped reference. When it's invalid, calling `GetEntityHealth` returns 0, which can lead to unintended behavior ([here](https://github.com/Rexshack-RedM/rsg-medic/blob/05dacfc337144da84cf06ec34e9c1a4c17e4cbca/client/client.lua#L262) and [here](https://github.com/Rexshack-RedM/rsg-medic/blob/05dacfc337144da84cf06ec34e9c1a4c17e4cbca/client/client.lua#L280)).

This causes at least one known issue related to player ped transitions - for example, when using the `/loadskin` command (random knock). This command is frequently used both in the framework codebase and by players.

**Fix**

Added a check using the native `DoesEntityExist` to verify that the `cache.ped` entity exists before accessing its health.